### PR TITLE
fix: headers and compilation flag for linux gcc & clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(runexe)
 
 set(CMAKE_CXX_STANDARD 98)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 set(SOURCE_FILES EntryPoint.cpp Configuration.cpp InvocationParams.cpp InvocationResult.cpp InvocationVerdict.cpp Strings.cpp Run.cpp Process.cpp Interaction.cpp)
 add_executable(runexe ${SOURCE_FILES})

--- a/EntryPoint.cpp
+++ b/EntryPoint.cpp
@@ -1,3 +1,6 @@
+#include <cstdio>
+#include <cstdlib>
+
 #include "Run.h"
 #include "Interaction.h"
 #include "Process.h"

--- a/Interaction.cpp
+++ b/Interaction.cpp
@@ -1,5 +1,7 @@
 #include <cstdio>
 #include <unistd.h>
+#include <signal.h>
+
 #include "Interaction.h"
 #include "Run.h"
 #include "Configuration.h"

--- a/Process.cpp
+++ b/Process.cpp
@@ -6,8 +6,15 @@
 #include <iostream>
 #include <vector>
 #include <csignal>
+#include <cstdlib>
+#include <unistd.h>
+#include <climits>
+#include <errno.h>
 
+#include <sys/wait.h>
+#include <sys/resource.h>
 #include <sys/time.h>
+
 #include <unistd.h>
 
 #include "Process.h"


### PR DESCRIPTION
Added some headers and one compilation flag to fix compilation errors on linux (tested on Ubuntu 20.04 with GCC and CLang)